### PR TITLE
Make a place for JCB weekly public minutes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,5 +31,5 @@ EC members allocate time during our weekly scheduled meetings to review new issu
 operations
 meeting_notes/index
 office_hours/index
-reports/index
+reports/communitybuilding/readme
 ```

--- a/docs/reports/communitybuilding/minutes_2024.md
+++ b/docs/reports/communitybuilding/minutes_2024.md
@@ -1,0 +1,13 @@
+# Jupyter Community Building Working Group 2024 Meeting Minutes
+
+
+## 23 May 2024
+
+* EC Reports: We reviewed and discussed 2023 H2 (second half of 2023) and discussed 2024 H1. This led to discussion surrounding cadence of reports and led to a bigger conversation about transparency and weekly minutes. 
+* Transparency: Improving transparency for this working group
+* Public minutes need to be established. Jason will create a place in the EC team compass for our weekly public minutes
+* Reviewed options for publishing minutes on GH
+  * POV of non engineer - GH is not user friendly, can be confusing
+  * Maintainer Summit - Jason attended
+    * Jason feels like we have GH’s ear about feedback we want to give about functionality and features. If we encounter issues we should keep that in mind. Figure out what our top ask is if we want to submit. 
+* Community Interviews: Tabled the discussion of recommendations in the community survey report in favor of discussion above

--- a/docs/reports/communitybuilding/readme.md
+++ b/docs/reports/communitybuilding/readme.md
@@ -1,5 +1,9 @@
 # Jupyter Community Building Working Group
 
+The Jupyter Community Building Working Group (JCB) acts on behalf of the Project Jupyter Executive Council with the objective of growing, building, and connecting the Jupyter community of users and contributors. For more information, see the [JCB Charter](https://jupyter.org/governance/communitybuildingworkinggroup.html).
+
+To contact the JCB privately, email the JCB mailing list at <jupyter-community-building-working-group@googlegroups.com>. This email list is open for public posting, but the public cannot read messages or archives.
+
 ```{toctree}
-report_2023H1
+2024 Meeting Minutes <minutes_2024.md>
 ```


### PR DESCRIPTION
The JCB wants to be better about transparent public minutes of our meeting discussion. Since having our own team compass seems too heavy for what we'd like to publish, we are treating our space on the EC team compass as our lightweight team compass.

CC @marthacryan