### PR TITLE
Add survey report to table of contents

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ language = 'en'
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+html_extra_path = ['reports/communitybuilding/Jupyter_Community_Building_Survey_Report_2024.pdf']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/reports/communitybuilding/readme.md
+++ b/docs/reports/communitybuilding/readme.md
@@ -6,4 +6,5 @@ To contact the JCB privately, email the JCB mailing list at <jupyter-community-b
 
 ```{toctree}
 2024 Meeting Minutes <minutes_2024.md>
+2024 Community Building Survey Report <https://jupyter.org/governance/Jupyter_Community_Building_Survey_Report_2024.pdf>
 ```


### PR DESCRIPTION
* Adds the survey report as a page to the governance docs
* Adds a link to that page to the ToC under "Jupyter Community Building Working Group"

I tested this locally! 