### PR TITLE
Update link to survey report in table of contents

### DIFF
--- a/docs/reports/communitybuilding/readme.md
+++ b/docs/reports/communitybuilding/readme.md
@@ -6,5 +6,5 @@ To contact the JCB privately, email the JCB mailing list at <jupyter-community-b
 
 ```{toctree}
 2024 Meeting Minutes <minutes_2024.md>
-2024 Community Building Survey Report <https://jupyter.org/governance/Jupyter_Community_Building_Survey_Report_2024.pdf>
+2024 Community Building Survey Report <https://executive-council-team-compass.readthedocs.io/en/latest/Jupyter_Community_Building_Survey_Report_2024.pdf>
 ```


### PR DESCRIPTION
Sorry one last PR! The link to the PDF was different than I expected :) This updates it to the correct link!