### PR TITLE
Add backlog of meeting minutes

### DIFF
--- a/docs/meeting_notes/2025.md
+++ b/docs/meeting_notes/2025.md
@@ -1,5 +1,103 @@
 # Meeting notes from 2025
 
+## Mar 04, 2025
+
+### Attendees
+
+* Zach Sailer  
+* Afshin Darian  
+* Chris Holdgraf  
+* Rick Wagner  
+* Jason Grout  
+* [part-time] Mike Wooster
+
+### Notes
+
+- **Process agreement for the EC.** We agreed that it’s important for the EC to trust one another’s judgment, and to bias towards action rather than asking the group for approval for everything in order to improve our efficiency.  
+- **Project Management capacity from LF.** We discussed whether the Jupyter Foundation should contract Project Management capacity from the Linux Foundation in order to assist us in administrative duties. Major concerns were that the cost of a LF PM is relatively high. Our likely plan will be to try a scoped trial period to learn more about how the PM can help the foundation be more effective, and decide how we’d like to move forward once we have more experience.  
+- **Foundation growth plans.** We ran through the pipeline of potential foundation members, and discussed our biggest opportunities and risks to the foundation. We agreed on the importance of ensuring the Foundation delivers clear value to the Jupyter Community, and to the member organizations. That is a short-term target for our time.  
+- **Facilitation at the LF summit.** The Jupyter Foundation board will meet in-person for the first time at the upcoming LF summit. We discussed whether there is value in using a facilitator to guide the conversation of that group. We decided to recommend this to the Jupyter Foundation Board and if there are no objections, move forward with this.  
+- **JupyterCon planning.** We are now in the content planning phase of JupyterCon and have identified a program chair. We should be on the lookout for keynote speakers and volunteers that can help with planning.
+
+
+
+## Feb 25, 2025
+
+### Attendees
+
+* Jason Grout  
+* Fernando Pérez  
+* Ana Ruvalcaba  
+* Afshin Darian  
+* Rick Wagner
+
+### Notes
+
+* **Discussion**: engaging the Jupyter Foundation more effectively. What mechanisms should we utilize to secure feedback from the community? How can we provide guidance and support to subprojects? For example, the EC can facilitate the Jupyter Foundation Governing Board approving pbudget for specific initiatives at the upcoming in-person meeting in March.  
+* **Discussion**: which communication channels does the EC commit to watching \- what are some standards we can implement within our group and expected response times? Reference https://executive-council-team-compass.readthedocs.io  
+* **JupyterCon**: we’re moving forward and working on launching CFP with the program chair for the event.
+
+## Feb 18, 2025
+
+### Attendees
+
+* Ana   
+* Chris Holdgraf (2i2c)  
+* Rick Wagner (SDSC)  
+* Darian  
+* Fernando (visiting)  
+* Brian (visiting)  
+* Zach (Apple)
+
+
+### Notes
+
+* Discussion of emeritus EC members potentially forming seed for an Advisory Committee, no decisions made yet  
+* Discussion of broad EC goals for 2025 (now that we have a new cohort, it’s a good time to re-examine):  
+  * Make sure launch of Jupyter Foundation is good for the stakeholders: the maintainer community who has been asking for support, the members of the Jupyter Foundation Governing Board, the user community  
+  * Hold a successful JupyterCon 2025
+
+## Feb 11, 2025
+
+### Attendees
+
+* Chris, Fernando, Jason unable to attend today  
+* Zach Sailer  
+* Ana Ruvalcaba  
+* Brian Granger  
+* Afshin Darian
+
+### Notes
+
+* Welcomed Rick to the EC\! Chris and Fernando were out for a CZI meeting.   
+* Worked on granting access to all things.  
+* Brian and Fernando plan to attend the next few meetings to help with the transition.  
+* Discussed individual plans for the LF Members summit. Rick, Ana, Jason, and Zach are confirmed to attend once finances for travel are settled.  
+* Discussed who could be a possible JupyterCon Program Chair.  
+* Discussed how to begin formulating a process to direct funding from Jupyter Foundation to Jupyter Subprojects.  
+  * The Jupyter Foundation aims to support the community.  
+  * We started brainstorming how to enable funding to reach maintainers. We will take this conversation to the JF Governing Board to continue brainstorming. Ideally, the process to request funds is lightweight and the EC should help support folks looking to request GB funds.  
+  * Specifically, we discussed Binder’s long term sustainability/funding. Binder is not just a service for tmp notebooks; it’s critical CI for JupyterLab Pull Request.  
+* Discussed the topic of transparency in EC elections  
+  * [https://github.com/jupyter/governance/issues/255](https://github.com/jupyter/governance/issues/255)  
+  * We discussed the pros/cons of transparent voting; it’s important to acknowledge this isn’t an easy topic. The goal is some folks in this meeting plan to respond to that issue to give more context.
+
+## Jan 21, 2025
+
+### Attendees
+
+* Zach  
+* Jason  
+* Darian  
+* Fernando  
+* Brian  
+* Ana (asked to hold off on joining meeting as funding discussion happening)
+
+### Notes
+
+* Fundraising discussion and update with VP Sales LF  
+* Discussion of proposal from Ana for recalibration and stability of funding
+
 ## 14 January 2025
 
 ### Attendees


### PR DESCRIPTION
This adds a backlog of meeting minutes for the JEC. I copied over all the minutes and attendance as-is for the historical meetings back to the last time we had written them down here. If there weren't any minutes, I skipped the meeting (it seemed like most of these were one-off meetings and not formal JEC meetings?). Some of these pre-date my being on the JEC so it is worth double-checking them but is probably safe to go with.