### PR TITLE
Add 'needs triage' label to new/reopened issues.

### DIFF
--- a/.github/needs_triage.yml
+++ b/.github/needs_triage.yml
@@ -1,0 +1,18 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: needs triage


### PR DESCRIPTION
We followed the instructions [here](https://docs.github.com/en/actions/use-cases-and-examples/project-management/adding-labels-to-issues#introduction)

Closes #122 