### PR TITLE
Update on delegation

### DIFF
--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -7,10 +7,7 @@ We share all Jupyter passwords in a 1Password account.
 All JEC team members should have access to this account.
 If you do not, ask another team member for access.
 
-Avoid as much as possible to use this service when delegation is possible,
-for many services you can login as _yourself_ and have access to the Jupyter
-accounts. This is critical in case of a break to know _whose account_ was
-breach, and which action from which member need to be reviewed.
+**Prefer delegating to user accounts over using the shared account**. 1Password lets you [delegate access and authority to user accounts](https://1password.com/features/user-management/) which is preferred over using the shared account.
 
 ## Google Workspace account
 
@@ -21,10 +18,8 @@ Each EC member has access to a Google Workspace account tied to the jupyter.org 
 We have a shared GMail account at `projectjupyter@gmail.com`. This is different from the Google Workspaces account defined above, and is from earlier phases of the project.
 This is used as a common login for many services and tools that we use.
 
-`projectjupyter@gmail.com` supports delegation; do not use the [](#passwords)
-service. Ask to be added as a delegated user if you do not know how to do it.
-Delegated accounts appear with a key symbol followed by `delegated` in the user
-switcher.
+**To access the Jupyter gmail account** ask a team member to add you as a "delegated user" if you do not know how to do it.
+Delegated accounts appear with a key symbol followed by `delegated` in the user switcher.
 
 ## Google Calendar
 
@@ -42,6 +37,6 @@ Jupyter has a CloudFlare account that controls the DNS for all of the Jupyter do
 
 All **Executive Council** members have access to this account.
 
-**Do not** access Cloudflare using the shared Jupyter [the Jupyter passwords
+**Delegate to user accounts rather than using the shared account**.  CloudFlare allows you to [delegate access and control to user accounts](https://developers.cloudflare.com/fundamentals/manage-members/manage/) which is strongly preferred over using the shared account.
 service](#passwords); create a Cloudflare account using your own
 username/password, and ask a Cloudflare admin to be added as a delegated user.


### PR DESCRIPTION
This updates best practices; 

If all EC member DM me their Cloudflare usernames/emails I can make them delegated. 
I *think* I should be able to do it for google as well.