### PR TITLE
Add 2026 notes to index

### DIFF
--- a/docs/meeting_notes/index.md
+++ b/docs/meeting_notes/index.md
@@ -7,4 +7,5 @@ The Jupyter Executive Council meets privately each week. A summary of meeting no
 2023
 2024
 2025
+2026
 ```


### PR DESCRIPTION
This was not showing up on https://ec.jupyter.org/meeting_notes/