### PR TITLE
Fix git markers

### DIFF
--- a/docs/meeting_notes/2025.md
+++ b/docs/meeting_notes/2025.md
@@ -438,7 +438,6 @@
 | Ana Ruvalcaba | Independent | X |
 | Chris Holdgraf | 2i2c |  |
 | Jason Grout | Independent | X |
-<<<<<<< HEAD
 | Rick Wagner | SDSC/UCSD |  |
 | Zach Sailer | Apple |  |
 
@@ -460,13 +459,10 @@
 | Ana Ruvalcaba | Independent | X |
 | Chris Holdgraf | 2i2c | X |
 | Jason Grout | Independent | X |
-=======
->>>>>>> 9724dcc (meeting minutes from oct 21)
 | Rick Wagner | SDSC/UCSD | X |
 | Zach Sailer | Apple | X |
 
 ### Notes
-<<<<<<< HEAD
 
 * EC Election
   * PMO will put together a document for the EC election process
@@ -512,20 +508,6 @@
   * Concerns: The group expressed significant concerns about the proposal's length and the feasibility of enforcing its guidelines. They also acknowledged the need to address the strong ethical and moral opposition to AI, which stems from issues like intellectual property and environmental impact.
   * Community Impact: The Executive Council recognized that this conversation could consume a lot of energy and lead to "bikeshedding" and emotional debate. However, it was also suggested that the topic could be used to encourage participation in an upcoming strategic planning meeting.
 
-=======
-* Zoom Meetings
-    * PMO will send a poll for a new day/time for the weekly Security Council meeting
-    * PMO will add individuals to the Community Channel meeting
-* Plausible Update
-    * The Plausible annual subscription transaction is being flagged as fraud by the LF’s credit card provider.
-    * PMO is working with Plausible and its payment processor to resolve the issue.
-* Jupyter Community Proposals
-    * A private repo was created for discussion and voting
-        * Proposals were copied over from the public repo
-        * A tracking sheet was also created
-    * EC members will read the community proposals and be ready to discuss them on Friday.
-
->>>>>>> 9724dcc (meeting minutes from oct 21)
 ---
 
 ## 2025 August 26


### PR DESCRIPTION
Those were showing up in the rendered site in multiple places:

<img width="1236" height="366" alt="image" src="https://github.com/user-attachments/assets/c0719bb3-aca6-407f-aa42-9c06f1ac39c6" />
